### PR TITLE
value+maybe+nil,+thus+the+type+of+it+is+nil+too

### DIFF
--- a/resp.go
+++ b/resp.go
@@ -36,7 +36,7 @@ func (r *Resp) VerifyJson(bs []byte) {
 		typv := reflect.TypeOf(v)
 		typwv := reflect.TypeOf(wv)
 		if !reflect.DeepEqual(v, wv) {
-			log.WithField("path", ks).Errorf("%+v [%s] is goten, %+v [%s] is wanted.", v, typv, wv, typwv)
+			log.WithField("path", ks).Errorf("%+v [%+v] is goten, %+v [%s] is wanted.", v, typv, wv, typwv)
 		}
 	}
 }

--- a/tg/tgrpc.toml
+++ b/tg/tgrpc.toml
@@ -40,3 +40,12 @@
       [Language.invokes.resp.json]
         'langs,0,birthday' = 1136185445.0
         totalCount = 999.0
+        'langs,1,versions,0,id' = 700.0
+        'langs,1,versions,0,vi32s,0' = 111.0
+        'langs,1,versions,0,vi32s' = [111.0,222.0]
+        'langs,1,versions,0,vi64s,0' = 111.0
+        'langs,1,versions,0,vi64s' = [111.0,222.0]
+        'langs,1,versions,0,vf64s,0' = 111.0
+        'langs,1,versions,0,vf64s' = [111.0,222.0]
+        'langs,1,versions,0,vstrs,0' = 'str1'
+        'langs,1,versions,0,vstrs' = ['str1','str2']


### PR DESCRIPTION
1. type of v use fmt: %+v, because v may be nil.

2. example of verify resp-json
